### PR TITLE
Improved completion

### DIFF
--- a/autoload/neocomplcache/sources/ghc.vim
+++ b/autoload/neocomplcache/sources/ghc.vim
@@ -36,8 +36,8 @@ function! s:source.get_complete_words(cur_keyword_pos, cur_keyword_str)
   let l:line = getline('.')[0 : a:cur_keyword_pos]
   " force auto-completion on importing functions
   if neocomplcache#is_auto_complete() &&
-        \ l:line !~# '^import\>.*(' &&
-        \ l:line !~# '^\s\+[,(]' &&
+        \ l:line !~# '^import\>.\{-}(' &&
+        \ l:line !~# '^\s\+[[:alpha:],(]' &&
         \ len(a:cur_keyword_str) < g:neocomplcache_auto_completion_start_length
     return []
   endif

--- a/autoload/neocomplete/sources/ghc.vim
+++ b/autoload/neocomplete/sources/ghc.vim
@@ -37,8 +37,8 @@ function! s:source.gather_candidates(context)
 
   " force auto-completion on importing functions
   if neocomplete#is_auto_complete() &&
-        \ line !~# '^import\>.*(' &&
-        \ line !~# '^\s\+[,(]' &&
+        \ line !~# '^import\>.\{-}(' &&
+        \ line !~# '^\s\+[[:alpha:],(]' &&
         \ len(a:context.complete_str) <
         \   g:neocomplete#auto_completion_start_length
     return []


### PR DESCRIPTION
Currently, it cannot do completion in the following cases.

``` haskell
import Foo.Bar (fun1 -- completion ok in the first line of import
               ,fun2, fu
--                  ^^^ (1) second and later words when the line starts by comma
               (<
--             ^^ (2) operators (starts by parenthesis)
```

---

the other changes
- replaced s:last_matchend() by matchend() because calling matchend() only once is faster most often
