### PR TITLE
Add new GHC pragmas to omnicompleter

### DIFF
--- a/autoload/necoghc.vim
+++ b/autoload/necoghc.vim
@@ -1,7 +1,21 @@
 " http://www.haskell.org/ghc/docs/latest/html/users_guide/pragmas.html
 let s:pragmas = [
-      \ 'LANGUAGE', 'OPTIONS_GHC', 'INCLUDE', 'WARNING', 'DEPRECATED', 'INLINE',
-      \ 'NOINLINE', 'ANN', 'LINE', 'RULES', 'SPECIALIZE', 'UNPACK', 'SOURCE',
+      \ 'ANN',
+      \ 'DEPRECATED',
+      \ 'INCLUDE',
+      \ 'INLINE',
+      \ 'INLINABLE',
+      \ 'LANGUAGE',
+      \ 'LINE',
+      \ 'MINIMAL',
+      \ 'NOINLINE',
+      \ 'NOUNPACK',
+      \ 'OPTIONS_GHC',
+      \ 'RULES',
+      \ 'SOURCE',
+      \ 'SPECIALIZE',
+      \ 'UNPACK',
+      \ 'WARNING',
       \ ]
 
 function! necoghc#boot() "{{{


### PR DESCRIPTION
Add the new or missing pragmas `INLINABLE`, `MINIMAL`, and `NOUNPACK` to the omnicompleter. Also sort the list and put each item on its own line to improve future diffs.
