### PR TITLE
version check failed due to a new ghc-mod version

### DIFF
--- a/autoload/necoghc.vim
+++ b/autoload/necoghc.vim
@@ -344,8 +344,8 @@ function! s:dangling_import(n) "{{{
 endfunction "}}}
 
 function! necoghc#ghc_mod_version() "{{{
-  let l:ret = s:system(['ghc-mod'])
-  return matchstr(l:ret, 'ghc-mod version \zs\d\+\.\d\+\.\d\+')
+  let l:ret = s:system(['ghc-mod', 'version'])
+  return matchstr(l:ret, 'ghc-mod version \zs\d\+\.\d\+\.\d\+\.\d\+')
 endfunction "}}}
 
 function! s:synname(...) "{{{


### PR DESCRIPTION
The ghc-mod command now does not output the version without adding the parameter 'version'

Since the version number now has one digit more, this had to be added to the regex 
