### PR TITLE
ghc-mod now requires the 'version' command to print the version

### DIFF
--- a/autoload/necoghc.vim
+++ b/autoload/necoghc.vim
@@ -344,7 +344,7 @@ function! s:dangling_import(n) "{{{
 endfunction "}}}
 
 function! necoghc#ghc_mod_version() "{{{
-  let l:ret = s:system(['ghc-mod'])
+  let l:ret = s:system(['ghc-mod', 'version'])
   return matchstr(l:ret, 'ghc-mod version \zs\d\+\.\d\+\.\d\+')
 endfunction "}}}
 


### PR DESCRIPTION
As of https://github.com/kazu-yamamoto/ghc-mod/commit/5a4bec87559d2a6ea3db5c3ca516ab68f8c10387
