### PR TITLE
Add 'silent!' to delcommand in on_final()

### DIFF
--- a/autoload/neocomplete/sources/ghc.vim
+++ b/autoload/neocomplete/sources/ghc.vim
@@ -21,7 +21,7 @@ function! s:source.hooks.on_init(context)
 endfunction
 
 function! s:source.hooks.on_final(context)
-  delcommand NeoCompleteGhcMakeCache
+  silent! delcommand NeoCompleteGhcMakeCache
 endfunction
 
 function! s:source.get_complete_position(context)


### PR DESCRIPTION
Currently there's an error on exiting Vim caused by NeoComplete calling the `on_final` hook twice. The built-in NeoComplete sources use `silent! delcommand` (e.g. https://github.com/Shougo/neocomplete.vim/blob/master/autoload/neocomplete/sources/buffer.vim#L79) for that reason so I did the same thing here.