### PR TITLE
Check current line in s:extract_modules()

### DIFF
--- a/autoload/necoghc.vim
+++ b/autoload/necoghc.vim
@@ -307,7 +307,7 @@ function! s:extract_modules() "{{{
 
   let l:in_module = 0
   let l:line = 1
-  while l:line < line('.')
+  while l:line <= line('.')
     let l:str = getline(l:line)
     if l:str =~# '^import\s\+'
       let l:idx = matchend(l:str, '^import\s\+')


### PR DESCRIPTION
The cursor line is not checked for newly imported models after leaving insert mode. Using `<=` instead of `<` fixes that.