### PR TITLE
Put uses of `lcd` inside a `try`/`finally`

### DIFF
--- a/autoload/necoghc.vim
+++ b/autoload/necoghc.vim
@@ -275,10 +275,14 @@ function! necoghc#get_modules() "{{{
 endfunction "}}}
 
 function! s:ghc_mod(cmd) "{{{
-  lcd `=expand('%:p:h')`
-  let l:cmd = ['ghc-mod'] + a:cmd
-  let l:ret = s:system(l:cmd)
-  lcd -
+  let l:dir = getcwd()
+  try
+    lcd `=expand('%:p:h')`
+    let l:cmd = ['ghc-mod'] + a:cmd
+    let l:ret = s:system(l:cmd)
+  finally
+    lcd `=l:dir`
+  endtry
   let l:lines = split(l:ret, '\r\n\|[\r\n]')
   if empty(l:lines)
     if get(g:, 'necoghc_debug', 0)


### PR DESCRIPTION
Sometimes the code between the two uses of `lcd` seems to fail, leaving the editor in the temporary location, which unfortunately confuses ghc-mod. (Specifically, it causes completion to fail.)

related: eagletmt/ghcmod-vim#82