### PR TITLE
Added ability to use stack's ghc-mod instead of system global installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,15 @@ Usually it will be noisy if `ghc-mod browse Your.Project.Module` always
 fails.
 Use this flag only if you have some trouble.
 
+### `g:necoghc_use_stack`
+Default: 0
+
+Allow using stack's own ghc-mod.
+It will change direct `ghc-mod` mod calls to `stack exec --no-stack-exe ghc-mod
+--` instead.
+Use this flag if your globally installed ghc-mod doesn't work properly with your
+stack projects.
+
 ## Troubleshoot
 
 ### Q: neco-ghc does not work

--- a/autoload/necoghc.vim
+++ b/autoload/necoghc.vim
@@ -363,13 +363,11 @@ function! s:ghc_mod_caching_async(lines, mod) abort "{{{
         let l:dict[l:m[1]] = {'type': l:m[2]}
       elseif l:line =~# '^\S\+$'
         let l:dict[l:line] = {}
-      else
+      elseif l:line != ""
         " Maybe some error occurred.
-        if l:line != ""
-          echohl ErrorMsg
-          echomsg printf('neco-ghc: %s', l:line)
-          echohl None
-        endif
+        echohl ErrorMsg
+        echomsg printf('neco-ghc: %s', l:line)
+        echohl None
       endif
     endif
   endfor

--- a/autoload/necoghc.vim
+++ b/autoload/necoghc.vim
@@ -26,9 +26,15 @@ let s:is_async = has('nvim')
 let s:job_info = {}
 let s:max_processes = 5
 
+let s:ghc_mod_path = ['ghc-mod']
+
 function! necoghc#boot() abort "{{{
   if exists('s:browse_cache')
     return
+  endif
+
+  if get(g:, 'necoghc_use_stack', 0)
+    let s:ghc_mod_path = ['stack', 'exec', '--no-stack-exe', 'ghc-mod', '--']
   endif
 
   let s:browse_cache = {}
@@ -272,7 +278,7 @@ function! s:ghc_mod_caching_browse(mod) abort "{{{
   endif
 
   if has('nvim')
-    let l:id = jobstart(['ghc-mod'] + l:cmd, {
+    let l:id = jobstart(s:ghc_mod_path + l:cmd, {
           \ 'on_stdout': function('s:job_handler'),
           \ 'on_stderr': function('s:job_handler'),
           \ 'on_exit': function('s:job_handler'),
@@ -291,7 +297,7 @@ function! s:ghc_mod_caching_browse(mod) abort "{{{
         let shellslash = &shellslash
         set noshellslash
       endif
-      let l:job = job_start(['ghc-mod'] + l:cmd, {
+      let l:job = job_start(s:ghc_mod_path + l:cmd, {
             \   'callback': function('s:job_handler_vim'),
             \ })
       let l:id = s:channel2id(job_getchannel(l:job))
@@ -359,9 +365,11 @@ function! s:ghc_mod_caching_async(lines, mod) abort "{{{
         let l:dict[l:line] = {}
       else
         " Maybe some error occurred.
-        echohl ErrorMsg
-        echomsg printf('neco-ghc: %s', l:line)
-        echohl None
+        if l:line != ""
+          echohl ErrorMsg
+          echomsg printf('neco-ghc: %s', l:line)
+          echohl None
+        endif
       endif
     endif
   endfor
@@ -388,7 +396,7 @@ function! necoghc#get_modules() abort "{{{
 endfunction "}}}
 
 function! s:ghc_mod(cmd) abort "{{{
-  let l:cmd = ['ghc-mod'] + a:cmd
+  let l:cmd = s:ghc_mod_path + a:cmd
   let l:lines = split(s:system(l:cmd), '\r\n\|[\r\n]')
 
   let l:warnings = filter(copy(l:lines), "v:val =~# '^Warning:'")
@@ -504,7 +512,7 @@ function! s:dangling_import(n) abort "{{{
 endfunction "}}}
 
 function! necoghc#ghc_mod_version() abort "{{{
-  let l:ret = s:system(['ghc-mod', 'version'])
+  let l:ret = s:system(s:ghc_mod_path + ['version'])
   return matchstr(l:ret, '\cghc-mod\%(.exe\)\?\s\+version\s\+\zs\%(\d\+\.\)*\d\+')
 endfunction "}}}
 
@@ -551,7 +559,7 @@ function! s:get_ghcmod_root() abort "{{{
     try
       lcd `=fnamemodify(bufname('%'), ':p:h')`
       let b:ghcmod_root =
-        \ substitute(s:system(['ghc-mod', 'root']), '\n*$', '', '')
+        \ substitute(s:system(s:ghc_mod_path + ['root']), '\n*$', '', '')
     finally
       lcd `=l:dir`
     endtry


### PR DESCRIPTION
This adds an option to use `stack exec --no-stack-exe ghc-mod --` instead of relying on global `$PATH` for ghc-mod. It allows the plugin to be used inside stack projects. It's very raw and I'm open to suggestions to make this PR better.

Thanks in advance!